### PR TITLE
Fix packArchive task for sbt 1.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,5 +75,5 @@ lazy val manager = project.in(file("manager"))
     packGenerateWindowsBatFile := true,
     packArchivePrefix := "scalabrad",
     // Only build tar.gz archives; skip .zip
-    packArchive := Seq(packArchiveTgz.value)
+    packArchive := Seq((Compile / packArchiveTgz).value)
   )


### PR DESCRIPTION
## Summary
- call packArchiveTgz from the Compile configuration so sbt 1.11 finds the task

## Testing
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_e_68400b430b14832692dca3b1756e4fcf